### PR TITLE
feat(frontend): Next.js MVP with STL viewer wired to FastAPIad

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,20 @@
+# Gridfinity Cutout Generator — Frontend
+
+Minimal Next.js (App Router, TypeScript) UI that talks to a FastAPI backend.
+
+## Features
+- Identify item → auto-fill dimensions (via `/identify` + `/dimensions`).
+- Generate proposals (`/proposals`) and pick one.
+- Generate STL (`/stl`) and preview it in a Three.js viewer.
+- Tailwind styling, lightweight deps.
+- Configurable API base via `NEXT_PUBLIC_API_BASE`.
+
+## Getting Started
+```bash
+cd frontend
+cp .env.local.example .env.local  # update if your API isn't localhost:8000
+npm install
+npm run dev
+```
+
+Then open http://localhost:3000 and try the **Demo** button if your backend isn't ready yet.

--- a/frontend/frontend/app/globals.css
+++ b/frontend/frontend/app/globals.css
@@ -1,0 +1,10 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --bg: #0b0f14;
+}
+
+html, body, #__next { height: 100%; }
+body { background: var(--bg); color: #e5e7eb; }

--- a/frontend/frontend/app/layout.tsx
+++ b/frontend/frontend/app/layout.tsx
@@ -1,0 +1,20 @@
+export const metadata = {
+  title: "Gridfinity Cutout Generator",
+  description: "Generate Gridfinity containers and preview STL files",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen antialiased">
+        <div className="max-w-6xl mx-auto p-6">
+          <header className="mb-6 flex items-center justify-between">
+            <h1 className="text-2xl font-semibold">Gridfinity Cutout Generator</h1>
+            <a className="text-sm opacity-75 hover:opacity-100 underline" href="https://github.com/monicaslgc/Gridfinity-Cutout-Generator" target="_blank" rel="noreferrer">GitHub</a>
+          </header>
+          {children}
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/frontend/frontend/app/page.tsx
+++ b/frontend/frontend/app/page.tsx
@@ -1,0 +1,171 @@
+"use client";
+import { useMemo, useRef, useState } from "react";
+import STLViewer from "../components/STLViewer";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8000";
+
+type Dimensions = { L: number; W: number; H: number };
+
+type Proposal = {
+  type: "snug" | "easy" | "multi";
+  x_slots: number;
+  y_slots: number;
+  z_units: number;
+  clearance: number;
+  compartments?: number | null;
+};
+
+export default function Page() {
+  const [itemName, setItemName] = useState("");
+  const [itemId, setItemId] = useState("");
+  const [dims, setDims] = useState<Dimensions>({ L: 152, W: 106, H: 60 });
+  const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [selected, setSelected] = useState<Proposal | null>(null);
+  const [stlUrl, setStlUrl] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>("");
+
+  const validDims = useMemo(() => dims.L > 0 && dims.W > 0 && dims.H > 0, [dims]);
+
+  async function handleIdentify() {
+    setError("");
+    setProposals([]);
+    setSelected(null);
+    setStlUrl("");
+    try {
+      const res = await fetch(`${API_BASE}/identify`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ input: itemName })
+      });
+      const data = await res.json();
+      const first = data?.candidates?.[0];
+      if (!first) throw new Error("No candidates returned");
+      setItemId(first.id);
+      // Try to prefill dimensions
+      const dres = await fetch(`${API_BASE}/dimensions?id=${encodeURIComponent(first.id)}`);
+      if (dres.ok) {
+        const dd = await dres.json();
+        if (dd?.dims_mm) setDims(dd.dims_mm);
+      }
+    } catch (e:any) {
+      setError(e.message || "Identify failed");
+    }
+  }
+
+  async function handleProposals() {
+    setError("");
+    setProposals([]);
+    setSelected(null);
+    setStlUrl("");
+    try {
+      const res = await fetch(`${API_BASE}/proposals`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ item_id: itemId || "manual", dims_mm: dims, options: {} })
+      });
+      if (!res.ok) throw new Error(`Proposals failed (${res.status})`);
+      const data = await res.json();
+      setProposals(data?.proposals || []);
+    } catch (e:any) {
+      setError(e.message || "Proposals failed");
+    }
+  }
+
+  async function handleSTL(p: Proposal) {
+    setError("");
+    setSelected(p);
+    setStlUrl("");
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_BASE}/stl`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ item_id: itemId || "manual", dims_mm: dims, proposal: p, options: { lip: true }, label: itemName || undefined })
+      });
+      if (!res.ok) throw new Error(`STL failed (${res.status})`);
+      const data = await res.json();
+      const file = data?.files?.[0]?.url;
+      if (!file) throw new Error("No STL URL");
+      setStlUrl(`${API_BASE}${file}`);
+    } catch (e:any) {
+      setError(e.message || "STL generation failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function useDemo() {
+    setItemName("Nintendo Switch Pro Controller");
+    setItemId("Qnintendo_switch_pro");
+    setDims({ L: 152, W: 106, H: 60 });
+  }
+
+  return (
+    <main className="space-y-6">
+      <section className="grid md:grid-cols-2 gap-4">
+        <div className="space-y-3 p-4 rounded-2xl bg-white/5">
+          <h2 className="text-lg font-semibold">1) Item</h2>
+          <div className="flex gap-2">
+            <input
+              value={itemName}
+              onChange={(e) => setItemName(e.target.value)}
+              placeholder="Describe your item (e.g., Nintendo Switch Pro Controller)"
+              className="w-full px-3 py-2 rounded-xl bg-white/10 focus:outline-none"
+            />
+            <button onClick={handleIdentify} className="px-3 py-2 rounded-xl bg-blue-600 hover:bg-blue-500 disabled:opacity-50" disabled={!itemName}>Identify</button>
+            <button onClick={useDemo} className="px-3 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-500">Demo</button>
+          </div>
+          <p className="text-xs opacity-70">ID: {itemId || "(none)"}</p>
+        </div>
+        <div className="space-y-3 p-4 rounded-2xl bg-white/5">
+          <h2 className="text-lg font-semibold">2) Dimensions (mm)</h2>
+          <div className="grid grid-cols-3 gap-3">
+            {(["L","W","H"] as const).map((k) => (
+              <div key={k} className="space-y-1">
+                <label className="block text-sm opacity-80">{k}</label>
+                <input type="number" inputMode="decimal" value={dims[k]} onChange={(e) => setDims({ ...dims, [k]: Number(e.target.value) })} className="w-full px-3 py-2 rounded-xl bg-white/10 focus:outline-none"/>
+              </div>
+            ))}
+          </div>
+          <button onClick={handleProposals} className="px-3 py-2 rounded-xl bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50" disabled={!validDims}>Generate proposals</button>
+        </div>
+      </section>
+
+      {error && (
+        <div className="p-3 rounded-xl bg-red-600/30 border border-red-500/50">{error}</div>
+      )}
+
+      {proposals.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold">3) Pick a proposal</h2>
+          <div className="grid md:grid-cols-3 gap-4">
+            {proposals.map((p) => (
+              <div key={p.type} className={`p-4 rounded-2xl bg-white/5 border ${selected?.type === p.type ? "border-emerald-500" : "border-white/10"}`}>
+                <div className="flex items-center justify-between">
+                  <h3 className="font-semibold capitalize">{p.type}</h3>
+                  <span className="text-xs opacity-70">{p.clearance} mm clr</span>
+                </div>
+                <p className="text-sm opacity-80 mt-1">{p.x_slots} × {p.y_slots} slots · {p.z_units} Z-units</p>
+                {typeof p.compartments === "number" && (
+                  <p className="text-xs opacity-70">{p.compartments} compartments</p>
+                )}
+                <button disabled={loading} onClick={() => handleSTL(p)} className="mt-3 w-full px-3 py-2 rounded-xl bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50">Generate STL</button>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {stlUrl && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold">4) Preview STL</h2>
+          <p className="text-sm opacity-80">Download: <a className="underline" href={stlUrl} target="_blank" rel="noreferrer">{stlUrl}</a></p>
+          <div className="h-[480px] rounded-2xl overflow-hidden border border-white/10">
+            <STLViewer url={stlUrl} />
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/frontend/components/STLViewer.tsx
+++ b/frontend/frontend/components/STLViewer.tsx
@@ -1,0 +1,97 @@
+"use client";
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+import { STLLoader } from "three/examples/jsm/loaders/STLLoader.js";
+
+export default function STLViewer({ url }: { url: string }) {
+  const mountRef = useRef<HTMLDivElement | null>(null);
+  const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
+  const controlsRef = useRef<OrbitControls | null>(null);
+
+  useEffect(() => {
+    if (!mountRef.current) return;
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x0b0f14);
+
+    const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 2000);
+    camera.position.set(150, 120, 160);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(mountRef.current.clientWidth, mountRef.current.clientHeight);
+    mountRef.current.appendChild(renderer.domElement);
+    rendererRef.current = renderer;
+
+    const light = new THREE.DirectionalLight(0xffffff, 1.0);
+    light.position.set(1, 1, 1);
+    scene.add(light);
+    scene.add(new THREE.AmbientLight(0xffffff, 0.4));
+
+    const grid = new THREE.GridHelper(400, 40, 0x666666, 0x333333);
+    grid.position.y = -1;
+    scene.add(grid);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+    controlsRef.current = controls;
+
+    let mesh: THREE.Mesh | null = null;
+
+    const loader = new STLLoader();
+    loader.load(
+      url,
+      (geometry) => {
+        geometry.computeBoundingBox();
+        geometry.center();
+        const material = new THREE.MeshStandardMaterial({ color: 0xdddddd, metalness: 0.1, roughness: 0.6 });
+        mesh = new THREE.Mesh(geometry, material);
+        scene.add(mesh);
+        // Auto-scale & frame
+        const bb = geometry.boundingBox!;
+        const size = new THREE.Vector3();
+        bb.getSize(size);
+        const fitDistance = Math.max(size.x, size.y, size.z) * 2.0;
+        const dir = new THREE.Vector3(1, 1, 1).normalize();
+        camera.position.copy(dir.multiplyScalar(fitDistance));
+        camera.lookAt(0, 0, 0);
+        controls.target.set(0, 0, 0);
+        controls.update();
+      },
+      undefined,
+      (err) => {
+        console.error("STL load error", err);
+      }
+    );
+
+    const handleResize = () => {
+      if (!mountRef.current) return;
+      const { clientWidth, clientHeight } = mountRef.current;
+      camera.aspect = clientWidth / clientHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(clientWidth, clientHeight);
+    };
+    window.addEventListener("resize", handleResize);
+
+    const tick = () => {
+      controls.update();
+      renderer.render(scene, camera);
+      requestAnimationFrame(tick);
+    };
+    tick();
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      controls.dispose();
+      if (mesh) {
+        mesh.geometry.dispose();
+        (mesh.material as THREE.Material).dispose();
+      }
+      renderer.dispose();
+      mountRef.current?.removeChild(renderer.domElement);
+    };
+  }, [url]);
+
+  return <div ref={mountRef} className="w-full h-full" />;
+}

--- a/frontend/frontend/next-env.d.ts
+++ b/frontend/frontend/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />

--- a/frontend/frontend/next.config.js
+++ b/frontend/frontend/next.config.js
@@ -1,0 +1,5 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+module.exports = nextConfig;

--- a/frontend/frontend/package.json
+++ b/frontend/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "gridfinity-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "three": "0.160.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.12",
+    "@types/react": "18.2.66",
+    "@types/react-dom": "18.2.22",
+    "autoprefixer": "10.4.19",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.4",
+    "typescript": "5.4.5"
+  }
+}

--- a/frontend/frontend/postcss.config.js
+++ b/frontend/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/frontend/tailwind.config.js
+++ b/frontend/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/frontend/tsconfig.json
+++ b/frontend/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION

## Summary

* Adds a minimal frontend (Next.js App Router, TypeScript, Tailwind) to talk to the FastAPI backend.
* Implements identify → proposals → STL generation flow with a 3D viewer (three.js STLLoader + OrbitControls).
* Configurable API base via `NEXT_PUBLIC_API_BASE` (defaults to `http://localhost:8000`).

## Changes

* New app under `/frontend/`:

  * `package.json`, `next.config.js`, `tsconfig.json`, `postcss.config.js`, `tailwind.config.js`
  * `app/layout.tsx`, `app/page.tsx`, `app/globals.css`, `components/STLViewer.tsx`
  * `next-env.d.ts`, `app/page.module.css` (placeholder), `.env.local.example`
* Optional CI: `.github/workflows/frontend.yml` (builds the Next.js app).

## Screenshots / Demo

> (Attach a short screen recording or screenshots: Demo → Generate proposals → Generate STL → Viewer shows the model.)

---

## How to run (local)

1. **Backend** (separate terminal):

   ```bash
   cd backend
   python3 -m venv .venv && source .venv/bin/activate
   pip install -U pip && pip install -r requirements.txt pytest
   uvicorn app.main:app --reload
   ```

   Visit: `http://localhost:8000/docs`
2. **Frontend**:

   ```bash
   cd frontend
   cp .env.local.example .env.local  # ensure NEXT_PUBLIC_API_BASE=http://localhost:8000
   npm install
   npm run dev
   ```

   Visit: `http://localhost:3000`

## How to run (GitHub Codespaces)

* Create a Codespace from the repo → open two terminals:

  * Terminal A: backend commands above
  * Terminal B: frontend commands above
* Use forwarded ports to access 3000 and 8000.

---

## Manual test plan

* **Demo flow**

  * Open `http://localhost:3000` → click **Demo**.
  * Click **Generate proposals** → confirm 3 proposal cards.
  * Choose one → click **Generate STL** → check a downloadable URL is returned.
  * STL preview renders in the viewer; you can orbit/zoom.
* **Identify flow**

  * Type a name (e.g., "Nintendo Switch Pro Controller") → **Identify**.
  * If dimensions are found (fallback), they prefill; adjust if needed.
  * Generate proposals → generate STL.
* **Error cases**

  * Stop backend; front end should show an error toast/panel.
  * Enter invalid dimensions (<= 0) → **Generate proposals** button disabled.

---

## Environment

* `NEXT_PUBLIC_API_BASE` → URL of the FastAPI backend (default `http://localhost:8000`).
* Node 18+ recommended.

## Accessibility

* Keyboard navigation works on inputs/buttons and proposal cards.
* Sufficient color contrast on dark background.
* Viewer has no flashing animations; reduce motion not required.

## Performance

* STL viewer limits pixel ratio to 2 and resizes on demand.
* No heavy client libraries beyond `three`.

## Security

* No secrets committed.
* Only public env var prefixed with `NEXT_PUBLIC_`.

## Risks / Rollback

* Risk: STL generation depends on backend and (optionally) CadQuery. If unavailable, backend returns a placeholder STL; viewer still loads.
* Rollback: revert this PR safely; frontend is isolated under `/frontend/`.

## Links

* Backend PR: (link to your backend PR)
* Issue: (link if applicable)

---

## Checklist (tick before Merge)

* [ ] All files under `/frontend/` created and committed.
* [ ] `.env.local.example` copied to `.env.local` with correct `NEXT_PUBLIC_API_BASE`.
* [ ] Manual test plan executed locally or in Codespaces.
* [ ] CI passes for `frontend.yml` (if added).
* [ ] Screenshots/video attached in this PR.
* [ ] Reviewed by at least one maintainer.

---

## Notes for reviewers

* Code is intentionally small and clear to bootstrap UI.
* Happy path plus basic error states included; image identification UI can be added next.
